### PR TITLE
Include advanced filters prototype

### DIFF
--- a/app/assets/javascripts/open_cga.js
+++ b/app/assets/javascripts/open_cga.js
@@ -38,17 +38,17 @@ window.Modules = {};
 
             function showActiveFilters() {
                 var values = $.map(element.find('input:checked, input[type="text"]'), function(e) { return $(e).val() });
+                element.find('.glyphicon-ok').remove();
 
                 if (values.length > 0 && values.join('') != '') {
                   element.find('.js-selected-filters').text(values.join(', '));
                   element.addClass('filter-active');
-                  element.find('.glyphicon-plus').addClass('glyphicon-ok').removeClass('glyphicon-plus');
+                  element.find('.js-modal-link').prepend('<span class="glyphicon glyphicon-ok"></span>');
                   element.find('.js-options').addClass('hide');
                   element.find('.js-remove-filter').removeClass('hide');
                 } else {
                   element.find('.js-selected-filters').text('');
                   element.removeClass('filter-active');
-                  element.find('.glyphicon-ok').removeClass('glyphicon-ok').addClass('glyphicon-plus');
                   element.find('.js-options').removeClass('hide');
                   element.find('.js-remove-filter').addClass('hide');
                 }

--- a/app/assets/javascripts/open_cga.js
+++ b/app/assets/javascripts/open_cga.js
@@ -14,6 +14,16 @@ window.Modules = {};
         };
     };
 
+    Modules['label-toggle'] = function() {
+        this.start = function(element) {
+            element.on('click', '.js-label-toggle', toggle);
+            function toggle(event) {
+                var $label = $(event.target);
+                $label.toggleClass('active-label');
+            }
+        };
+    };
+
     Modules['filterable-list'] = function() {
         var that = this;
         that.start = function(element) {

--- a/app/assets/javascripts/open_cga.js
+++ b/app/assets/javascripts/open_cga.js
@@ -29,6 +29,8 @@ window.Modules = {};
             element.on('click', '.js-filter', showActiveFilters);
             element.on('click', '.js-remove-filter', removeFilter);
 
+            showActiveFilters();
+
             function removeFilter(event) {
               event.preventDefault();
               element.find('input:checked').prop('checked', false);
@@ -46,11 +48,14 @@ window.Modules = {};
                   element.find('.js-modal-link').prepend('<span class="glyphicon glyphicon-ok"></span>');
                   element.find('.js-options').addClass('hide');
                   element.find('.js-remove-filter').removeClass('hide');
+
+                  element.find('.js-categorical-value').val(values.join(','));
                 } else {
                   element.find('.js-selected-filters').text('');
                   element.removeClass('filter-active');
                   element.find('.js-options').removeClass('hide');
                   element.find('.js-remove-filter').addClass('hide');
+                  element.find('.js-categorical-value').val('');
                 }
             }
         };

--- a/app/assets/javascripts/open_cga.js
+++ b/app/assets/javascripts/open_cga.js
@@ -24,6 +24,38 @@ window.Modules = {};
         };
     };
 
+    Modules['filter'] = function() {
+        this.start = function(element) {
+            element.on('click', '.js-filter', showActiveFilters);
+            element.on('click', '.js-remove-filter', removeFilter);
+
+            function removeFilter(event) {
+              event.preventDefault();
+              element.find('input:checked').prop('checked', false);
+              element.find('input[type="text"]').val('');
+              showActiveFilters();
+            }
+
+            function showActiveFilters() {
+                var values = $.map(element.find('input:checked, input[type="text"]'), function(e) { return $(e).val() });
+
+                if (values.length > 0 && values.join('') != '') {
+                  element.find('.js-selected-filters').text(values.join(', '));
+                  element.addClass('filter-active');
+                  element.find('.glyphicon-plus').addClass('glyphicon-ok').removeClass('glyphicon-plus');
+                  element.find('.js-options').addClass('hide');
+                  element.find('.js-remove-filter').removeClass('hide');
+                } else {
+                  element.find('.js-selected-filters').text('');
+                  element.removeClass('filter-active');
+                  element.find('.glyphicon-ok').removeClass('glyphicon-ok').addClass('glyphicon-plus');
+                  element.find('.js-options').removeClass('hide');
+                  element.find('.js-remove-filter').addClass('hide');
+                }
+            }
+        };
+    };
+
     Modules['filterable-list'] = function() {
         var that = this;
         that.start = function(element) {

--- a/app/assets/sass/base.scss
+++ b/app/assets/sass/base.scss
@@ -237,6 +237,10 @@ th.sorted-asc .fa-arrow-down {
   margin-right: 8px;
 }
 
+.filter-panel .glyphicon-remove {
+  margin-right: 0;
+}
+
 .filter-panel .glyphicon-plus {
   color: #999;
 }

--- a/app/assets/sass/base.scss
+++ b/app/assets/sass/base.scss
@@ -228,3 +228,33 @@ th.sorted-asc .fa-arrow-down {
   margin-bottom: 5px;
   display: inline-block;
 }
+
+/* Filter panel
+   ========================================================================== */
+
+.filter-panel .glyphicon {
+  font-size: 80%;
+  margin-right: 8px;
+}
+
+.filter-panel .glyphicon-plus {
+  color: #999;
+}
+
+.filter-panel .glyphicon-ok {
+  color: green;
+}
+
+.filter-value {
+  color: #999;
+  margin-left: 20px;
+}
+
+.filter-active {
+  background: #f3f3f3;
+}
+
+.filter-action {
+  max-width: 200px;
+  margin: 0 auto;
+}

--- a/app/assets/sass/base.scss
+++ b/app/assets/sass/base.scss
@@ -258,3 +258,17 @@ th.sorted-asc .fa-arrow-down {
   max-width: 200px;
   margin: 0 auto;
 }
+
+.category-filter-label {
+  display: block;
+  border: 1px solid #ccc;
+  background: #f3f3f3;
+  margin: 5px 0;
+  padding: 3px 5px;
+  padding-left: 25px !important;
+  border-radius: 3px;
+}
+
+.category-filter-label.active-label {
+  background: #ddd;
+}

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,5 +1,6 @@
 var moment = require('moment'),
-    pluralize = require('pluralize');
+    pluralize = require('pluralize'),
+    slug = require('slug');
 
 module.exports = function(env) {
   var filters = {};
@@ -10,6 +11,10 @@ module.exports = function(env) {
 
   filters.pluralize = function(string, number) {
     return pluralize(string, number);
+  }
+
+  filters.slug = function(string) {
+    return slug(string);
   }
 
   filters.objectLength = function(obj) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -201,16 +201,26 @@ router.get('/project/:projectId/study/:studyId/jobs', auth, project, study, jobs
 router.get('/project/:projectId/study/:studyId/samples', auth, project, study, function (req, res, next) {
   var study = res.locals.params.study,
       variableSets = study.variableSets,
-      promise, search_params;
+      promise, search_params, query_params;
+
+  query_params = Object.assign({}, req.query);
+  Object.keys(query_params).forEach(function(key) {
+    if (query_params[key] == '') {
+      delete query_params[key];
+    }
+  });
 
   // TODO: Make this more reliable
   search_params = Object.assign({
     studyId: req.params.studyId,
-    sid: req.session.sid}, req.query);
+    sid: req.session.sid}, query_params);
 
   if (variableSets && variableSets.length > 0) {
     search_params['variableSetId'] = variableSets[0].id;
   }
+
+  console.log(req.query);
+  console.log(search_params);
 
   promise = res.locals.client.samples().search(search_params);
 
@@ -219,7 +229,7 @@ router.get('/project/:projectId/study/:studyId/samples', auth, project, study, f
         filters = sampleAnnotationSummary(samples, req.query),
         activeFilters = {};
 
-    for (var queryParam in req.query) {
+    for (var queryParam in query_params) {
       var annotation = queryParam.split('.')[1],
           filterQueryObject = Object.assign({}, req.query);
 
@@ -275,9 +285,11 @@ router.get('/project/:projectId/study/:studyId/samples/filters', auth, project, 
   }
 
   // TODO: Make this more reliable
-  search_params = Object.assign({
-    studyId: req.params.studyId,
-    sid: req.session.sid}, req.query);
+  search_params = Object.assign(
+      {
+        studyId: req.params.studyId,
+        sid: req.session.sid
+      }, req.query);
 
   if (variableSets && variableSets.length > 0) {
     search_params['variableSetId'] = variableSets[0].id;

--- a/app/routes.js
+++ b/app/routes.js
@@ -244,7 +244,8 @@ router.get('/project/:projectId/study/:studyId/samples', auth, project, study, f
     render(res, 'samples', {
       'samples': samples,
       'filters': filters,
-      'activeFilters': activeFilters
+      'activeFilters': activeFilters,
+      'full_width': true
     });
   }).catch(next);
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -263,17 +263,16 @@ router.get('/project/:projectId/study/:studyId/samples', auth, project, study, f
 router.get('/project/:projectId/study/:studyId/samples/filters', auth, project, study, function (req, res, next) {
   var study = res.locals.params.study,
       variableSets = study.variableSets,
-      variables = {categorical: [], text: [], numeric: []},
+      variables = {categorical: [], text: [], numeric: [], count: 0},
       promise, search_params;
 
   if (variableSets && variableSets.length > 0) {
     for (let variable of variableSets[0].variables) {
       var type = variable.type.toLowerCase();
-      variables[type].push(variable.name);
+      variables[type].push(variable);
+      variables.count++;
     }
   }
-
-  console.log(variables);
 
   // TODO: Make this more reliable
   search_params = Object.assign({

--- a/app/views/filter-modal.html
+++ b/app/views/filter-modal.html
@@ -1,0 +1,42 @@
+<li class="list-group-item" data-module="filter">
+  <a href="#{{ v.name|slug }}" class="js-modal-link" data-toggle="modal" data-target="#{{ v.name|slug }}">{{ v.name }}</a>
+  {% if v.type == 'CATEGORICAL' %}
+    <span class="pull-right text-muted js-options">{{ v.allowedValues|length }} {{'option'|pluralize(v.allowedValues|length)}}</span>
+  {% endif %}
+  <a href="#remove" class="pull-right inherit js-remove-filter hide"><span class="glyphicon glyphicon-remove"></span></a>
+  <div class="filter-value js-selected-filters"></div>
+
+  <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">Filter by ‘{{ v.name }}’</h4>
+        </div>
+        <div class="modal-body">
+            {% if v.type == 'CATEGORICAL' %}
+              <div class="row">
+                {% for allowed in v.allowedValues %}
+                    <div class="col-md-4">
+                      <div class="checkbox" style="margin: 0">
+                        <label class="category-filter-label js-label-toggle">
+                          <input type="checkbox" value="{{ allowed }}"> {{ allowed }}
+                        </label>
+                      </div>
+                    </div>
+                {% endfor %}
+              </div>
+            {% else %}
+              <div class="form-group">
+                <input type="text" name="{{ v.name|slug }}" class="form-control" />
+              </div>
+            {% endif %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default add-right-margin" data-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary js-filter" data-dismiss="modal">Update filter</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</li>

--- a/app/views/filter-modal.html
+++ b/app/views/filter-modal.html
@@ -5,6 +5,9 @@
   {% endif %}
   <a href="#remove" class="pull-right inherit js-remove-filter hide"><span class="glyphicon glyphicon-remove"></span></a>
   <div class="filter-value js-selected-filters"></div>
+  {% if v.type == 'CATEGORICAL' %}
+    <input type="hidden" name="annotation.{{ v.name }}" class="js-categorical-value" value="" />
+  {% endif %}
 
   <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
     <div class="modal-dialog">
@@ -28,7 +31,7 @@
               </div>
             {% else %}
               <div class="form-group">
-                <input type="text" name="{{ v.name|slug }}" class="form-control" />
+                <input type="text" name="annotation.{{ v.name }}" class="form-control" />
               </div>
             {% endif %}
         </div>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -1,0 +1,81 @@
+{% extends "layout.html" %}
+{% block page_title %}Filter samples{% endblock %}
+
+{% block content %}
+  <ol class="breadcrumb">
+    <li>
+      <a href="/">Projects</a>
+    </li>
+    <li>
+      <a href="/project/{{ project.id }}">{{ project.name }}</a>
+    </li>
+    <li>
+      <a href="/project/{{ project.id }}/study/{{ study.id }}">{{ study.name }}</a>
+    </li>
+    <li>
+      <a href="/project/{{ project.id }}/study/{{ study.id }}/samples">Samples</a>
+    </li>
+    <li class="active">
+      Filter samples
+    </li>
+  </ol>
+
+  <h1 class="add-bottom-margin">
+    20 variables
+  </h1>
+
+  <div class="panel panel-default filter-panel">
+    <div class="panel-heading">
+      <div class="panel-title">Filter</div>
+    </div>
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-md-4">
+          <h4 class="remove-top-margin">Categorical</h4>
+          <ul class="list-group">
+            {% for v in variables.categorical %}
+              <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-plus"></span>{{ v }}</a>
+              </li>
+            {% endfor %}
+            <!-- <li class="list-group-item filter-active"><a href="#"><span class="glyphicon glyphicon-ok"></span>affy_genotypes</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>omni genotypes</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>phase 3 genotypes</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>sex</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>related genotypes</a></li>
+            <li class="list-group-item filter-active"><a href="#"><span class="glyphicon glyphicon-ok"></span>Population</a><br /><span class="filter-value">GBR, FIN</span></li>-->
+          </ul>
+        </div>
+        <div class="col-md-4">
+          <h4 class="remove-top-margin">Text</h4>
+          <ul class="list-group">
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>fatherName</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Second Order</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Third Order</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>motherName</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Other Comments</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Relationship</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>name</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Children</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>family</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Siblings</a></li>
+          </ul>
+        </div>
+        <div class="col-md-4">
+          <h4 class="remove-top-margin">Numeric</h4>
+          <ul class="list-group">
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>motherId</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>fatherId</a></li>
+            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>id</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="panel-footer text-center">
+      <p class="text-muted add-label-margin">2 filters selected</p>
+      <input type="submit" class="btn btn-block btn-primary filter-action" value="Filter">
+    </div>
+  </div>
+
+
+{% endblock %}

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -34,42 +34,7 @@
           <h4 class="remove-top-margin">Categorical</h4>
           <ul class="list-group" data-module="label-toggle">
             {% for v in variables.categorical %}
-              <li class="list-group-item" data-module="filter">
-                <a href="#{{ v.name|slug }}" data-toggle="modal" data-target="#{{ v.name|slug }}">
-                  <span class="glyphicon glyphicon-plus"></span>{{ v.name }}
-                </a>
-                <span class="pull-right text-muted js-options">{{ v.allowedValues|length }} {{'option'|pluralize(v.allowedValues|length)}}</span>
-                <a href="#remove" class="pull-right inherit js-remove-filter hide"><span class="glyphicon glyphicon-remove"></span></a>
-                <div class="filter-value js-selected-filters"></div>
-
-                <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Filter by ‘{{ v.name }}’</h4>
-                      </div>
-                      <div class="modal-body">
-                        <div class="row">
-                        {% for allowed in v.allowedValues %}
-                            <div class="col-md-4">
-                              <div class="checkbox" style="margin: 0">
-                                <label class="category-filter-label js-label-toggle">
-                                  <input type="checkbox" value="{{ allowed }}"> {{ allowed }}
-                                </label>
-                              </div>
-                            </div>
-                        {% endfor %}
-                        </div>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-default add-right-margin" data-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn btn-primary js-filter" data-dismiss="modal">Update filter</button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </li>
+              {% include "filter-modal.html" %}
             {% endfor %}
           </ul>
         </div>
@@ -77,33 +42,7 @@
           <h4 class="remove-top-margin">Text</h4>
           <ul class="list-group">
             {% for v in variables.text %}
-              <li class="list-group-item" data-module="filter">
-                <a href="#{{ v.name|slug }}" data-toggle="modal" data-target="#{{ v.name|slug }}">
-                  <span class="glyphicon glyphicon-plus"></span>{{ v.name }}
-                </a>
-                <a href="#remove" class="pull-right inherit js-remove-filter hide"><span class="glyphicon glyphicon-remove"></span></a>
-                <div class="filter-value js-selected-filters"></div>
-
-                <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title">Filter by ‘{{ v.name }}’</h4>
-                      </div>
-                      <div class="modal-body">
-                        <div class="form-group">
-                          <input type="text" name="{{ v.name|slug }}" class="form-control" />
-                        </div>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-default add-right-margin" data-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn btn-primary js-filter" data-dismiss="modal">Update filter</button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </li>
+              {% include "filter-modal.html" %}
             {% endfor %}
           </ul>
         </div>
@@ -111,9 +50,7 @@
           <h4 class="remove-top-margin">Numeric</h4>
           <ul class="list-group">
             {% for v in variables.numeric %}
-              <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-plus"></span>{{ v.name }}</a>
-              </li>
+              {% include "filter-modal.html" %}
             {% endfor %}
           </ul>
         </div>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -34,11 +34,14 @@
           <h4 class="remove-top-margin">Categorical</h4>
           <ul class="list-group" data-module="label-toggle">
             {% for v in variables.categorical %}
-              <li class="list-group-item">
+              <li class="list-group-item" data-module="filter">
                 <a href="#{{ v.name|slug }}" data-toggle="modal" data-target="#{{ v.name|slug }}">
                   <span class="glyphicon glyphicon-plus"></span>{{ v.name }}
                 </a>
-                <span class="pull-right text-muted">{{ v.allowedValues|length }} {{'value'|pluralize(v.allowedValues|length)}}</span>
+                <span class="pull-right text-muted js-options">{{ v.allowedValues|length }} {{'option'|pluralize(v.allowedValues|length)}}</span>
+                <a href="#remove" class="pull-right inherit js-remove-filter hide"><span class="glyphicon glyphicon-remove"></span></a>
+                <div class="filter-value js-selected-filters"></div>
+
                 <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
                   <div class="modal-dialog">
                     <div class="modal-content">
@@ -52,7 +55,7 @@
                             <div class="col-md-4">
                               <div class="checkbox" style="margin: 0">
                                 <label class="category-filter-label js-label-toggle">
-                                  <input type="checkbox"> {{ allowed }}
+                                  <input type="checkbox" value="{{ allowed }}"> {{ allowed }}
                                 </label>
                               </div>
                             </div>
@@ -61,7 +64,7 @@
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-default add-right-margin" data-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn btn-primary">Add filter</button>
+                        <button type="button" class="btn btn-primary js-filter" data-dismiss="modal">Update filter</button>
                       </div>
                     </div>
                   </div>
@@ -74,8 +77,32 @@
           <h4 class="remove-top-margin">Text</h4>
           <ul class="list-group">
             {% for v in variables.text %}
-              <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-plus"></span>{{ v.name }}</a>
+              <li class="list-group-item" data-module="filter">
+                <a href="#{{ v.name|slug }}" data-toggle="modal" data-target="#{{ v.name|slug }}">
+                  <span class="glyphicon glyphicon-plus"></span>{{ v.name }}
+                </a>
+                <a href="#remove" class="pull-right inherit js-remove-filter hide"><span class="glyphicon glyphicon-remove"></span></a>
+                <div class="filter-value js-selected-filters"></div>
+
+                <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Filter by ‘{{ v.name }}’</h4>
+                      </div>
+                      <div class="modal-body">
+                        <div class="form-group">
+                          <input type="text" name="{{ v.name|slug }}" class="form-control" />
+                        </div>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default add-right-margin" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary js-filter" data-dismiss="modal">Update filter</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </li>
             {% endfor %}
           </ul>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -24,7 +24,7 @@
     {{ variables.count }} variables
   </h1>
 
-  <div class="panel panel-default filter-panel">
+  <form class="panel panel-default filter-panel" action="/project/{{ project.id }}/study/{{ study.id }}/samples" method="get">
     <div class="panel-heading">
       <div class="panel-title">Filter</div>
     </div>
@@ -60,7 +60,7 @@
       <p class="text-muted add-label-margin">2 filters selected</p>
       <input type="submit" class="btn btn-block btn-primary filter-action" value="Filter">
     </div>
-  </div>
+  </form>
 
 
 {% endblock %}

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -21,7 +21,7 @@
   </ol>
 
   <h1 class="add-bottom-margin">
-    20 variables
+    {{ variables.count }} variables
   </h1>
 
   <div class="panel panel-default filter-panel">
@@ -32,41 +32,62 @@
       <div class="row">
         <div class="col-md-4">
           <h4 class="remove-top-margin">Categorical</h4>
-          <ul class="list-group">
+          <ul class="list-group" data-module="label-toggle">
             {% for v in variables.categorical %}
               <li class="list-group-item">
-                <a href="#"><span class="glyphicon glyphicon-plus"></span>{{ v }}</a>
+                <a href="#{{ v.name|slug }}" data-toggle="modal" data-target="#{{ v.name|slug }}">
+                  <span class="glyphicon glyphicon-plus"></span>{{ v.name }}
+                </a>
+                <span class="pull-right text-muted">{{ v.allowedValues|length }} {{'value'|pluralize(v.allowedValues|length)}}</span>
+                <div class="modal" tabindex="-1" role="dialog" id="{{ v.name|slug }}">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Filter by ‘{{ v.name }}’</h4>
+                      </div>
+                      <div class="modal-body">
+                        <div class="row">
+                        {% for allowed in v.allowedValues %}
+                            <div class="col-md-4">
+                              <div class="checkbox" style="margin: 0">
+                                <label class="category-filter-label js-label-toggle">
+                                  <input type="checkbox"> {{ allowed }}
+                                </label>
+                              </div>
+                            </div>
+                        {% endfor %}
+                        </div>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default add-right-margin" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary">Add filter</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </li>
             {% endfor %}
-            <!-- <li class="list-group-item filter-active"><a href="#"><span class="glyphicon glyphicon-ok"></span>affy_genotypes</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>omni genotypes</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>phase 3 genotypes</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>sex</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>related genotypes</a></li>
-            <li class="list-group-item filter-active"><a href="#"><span class="glyphicon glyphicon-ok"></span>Population</a><br /><span class="filter-value">GBR, FIN</span></li>-->
           </ul>
         </div>
         <div class="col-md-4">
           <h4 class="remove-top-margin">Text</h4>
           <ul class="list-group">
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>fatherName</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Second Order</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Third Order</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>motherName</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Other Comments</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Relationship</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>name</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Children</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>family</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>Siblings</a></li>
+            {% for v in variables.text %}
+              <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-plus"></span>{{ v.name }}</a>
+              </li>
+            {% endfor %}
           </ul>
         </div>
         <div class="col-md-4">
           <h4 class="remove-top-margin">Numeric</h4>
           <ul class="list-group">
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>motherId</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>fatherId</a></li>
-            <li class="list-group-item"><a href="#"><span class="glyphicon glyphicon-plus"></span>id</a></li>
+            {% for v in variables.numeric %}
+              <li class="list-group-item">
+                <a href="#"><span class="glyphicon glyphicon-plus"></span>{{ v.name }}</a>
+              </li>
+            {% endfor %}
           </ul>
         </div>
       </div>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -9,7 +9,7 @@
   </head>
   <body class="{% block body_classes %}{% endblock %}">
     <div class="navbar navbar-inverse">
-      <div class="container">
+      <div class="{% if full_width %}container-fluid{% else %}container{% endif %}">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar">
             <span class="sr-only">Toggle navigation</span>
@@ -32,7 +32,7 @@
         </div>
       </div>
     </div>
-    <div class="container">
+    <div class="{% if full_width %}container-fluid{% else %}container{% endif %}">
       {% block content %}{% endblock %}
     </div>
     <script src="{{ asset_path }}javascripts/jquery-1.11.3.js"></script>

--- a/app/views/samples.html
+++ b/app/views/samples.html
@@ -22,7 +22,7 @@
   </h1>
 
   <div class="row">
-    <div class="col-md-3">
+    <div class="col-md-2">
       {% if activeFilters|objectLength > 0 %}
       <div class="panel panel-default">
         <div class="panel-heading">Active filters</div>
@@ -62,7 +62,7 @@
         </div>
       {% endfor %}
     </div>
-    <div class="col-md-9">
+    <div class="col-md-10">
       <table class="table table-bordered" data-module="filterable-table">
         <thead>
           <tr class="table-header">


### PR DESCRIPTION
A consideration of how to filter a larger sample set, when there could be potentially hundreds of variable types/annotations on which to filter by.
- Break down by category
- Hide options from main view until interacted with
- Indicate which filters are active
- Make it easier to remove filter

![filters-in-action](https://cloud.githubusercontent.com/assets/319055/17206721/03f496e0-54a9-11e6-88f1-92e15d5f9de5.gif)

![screen shot 2016-07-22 at 13 36 21](https://cloud.githubusercontent.com/assets/319055/17206681/c7a06782-54a8-11e6-9419-2699b022397c.png)
![screen shot 2016-07-22 at 11 24 33](https://cloud.githubusercontent.com/assets/319055/17206680/c7a04c66-54a8-11e6-878a-8425c70aac18.png)
